### PR TITLE
Add user-facing MkDocs documentation for exposed depth estimators

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,0 +1,10 @@
+# DepthEstimation
+
+This library provides simple, user-facing APIs for estimating depth from stereo images and stereo video streams.
+
+The library abstracts away internal image processing and stereo matching details, exposing only high-level estimator classes.
+
+## Supported Modes
+
+- Stereo depth from image pairs
+- Stereo depth from video streams

--- a/docs/docs/mono_depth.md
+++ b/docs/docs/mono_depth.md
@@ -1,0 +1,15 @@
+# Monocular Depth Estimation
+
+## MonoDepthEstimator
+
+The `MonoDepthEstimator` class estimates depth from a single RGB image using a pretrained deep learning model.
+
+This approach does not require stereo image pairs, but depth accuracy depends on model generalization and scene characteristics.
+
+### Constructor
+
+```python
+MonoDepthEstimator(
+    model_name: str = "Intel/dpt-large",
+    device: str = "cpu"
+)

--- a/docs/docs/stereo_image.md
+++ b/docs/docs/stereo_image.md
@@ -1,0 +1,14 @@
+# Stereo Depth from Images
+
+## StereoDepthEstimator
+
+The `StereoDepthEstimator` class estimates depth from a pair of rectified stereo images.
+
+### Constructor
+
+```python
+StereoDepthEstimator(
+    left_source: str,
+    right_source: str,
+    downscale_factor: float = 0.5
+)

--- a/docs/docs/stereo_video.md
+++ b/docs/docs/stereo_video.md
@@ -1,0 +1,15 @@
+
+# Stereo Depth from Video
+
+## StereoDepthEstimatorVideo
+
+The `StereoDepthEstimatorVideo` class performs depth estimation from synchronized stereo video streams.
+
+### Constructor
+
+```python
+StereoDepthEstimatorVideo(
+    left_source: str,
+    right_source: str,
+    downscale_factor: float = 0.5
+)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: DepthEstimation Documentation
+
+theme:
+  name: material
+
+nav:
+  - Home: index.md
+  - Stereo Depth:
+      - Stereo Image API: stereo_image.md
+      - Stereo Video API: stereo_video.md
+  - Monocular Depth:
+      - Mono Depth API: mono_depth.md


### PR DESCRIPTION
This PR adds a user-facing MkDocs documentation for the exposed depth estimation APIs.

Covered estimators:
- StereoDepthEstimator
- StereoDepthEstimatorVideo
- MonoDepthEstimator

The documentation intentionally focuses only on constructors, parameters, and usage examples, and avoids internal implementation details.